### PR TITLE
Add .gitignore file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+client_secrets.json
+/app_source/tmp
+/node_modules


### PR DESCRIPTION
@HsuTimothy 

This adds a gitignore file with the following:
* node_modules - this doesn't need to be checked in as it the dependant
on the machine that installed the modules. You can use npm shrinkwrap to
generate a "lock" file that ensures consistent versions will be used and
check that in instead.
* client_secret.json. This shouldn't be in source control. Really
anything with "secret" in it shouldn't be checked in. This can be setup
with an environment variable or some other mechanism when the app is
deployed. Then instructions can be added to the README.md to help each
developer create their own. Also a new one should be generated to
invalidate the current one that exists in git history.
* /app_source/tmp is just to not have the output of zat show up.