### PR TITLE
Add GitHub Actions workflows to migrate away from Travis-CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: ruby
-    runs-on: [ self-hosted, zendesk-stable]
+    runs-on: ubuntu-latest
     env:
       RAILS_ENV: test
       ZENDESK_HOST: 127.0.0.1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,27 @@
+name: repo-checks
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  main:
+    name: ruby
+    runs-on: [ self-hosted, zendesk-stable]
+    env:
+      RAILS_ENV: test
+      ZENDESK_HOST: 127.0.0.1
+    steps:
+    - uses: zendesk/checkout@v2
+    - uses: zendesk/setup-ruby@v1
+    - name: gem_cache
+      id: cache
+      uses: zendesk/cache@v2
+      with:
+        path: vendor/bundle
+        key: cache-${{ runner.os }}-ruby-${{ hashFiles('Gemfile.lock') }}
+    - name: install
+      run: |
+        bundle install --jobs=3 --retry=3 --quiet
+    - name: test 
+      run: |
+        bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-cache: bundler
-language: ruby
-script: bundle exec rspec
-sudo: false
-git:
-  depth: 1

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![repo-checks](https://github.com/zendesk/Youtube_Integration/workflows/repo-checks/badge.svg)
 # Youtube Integration <img src="https://www.dropbox.com/s/uz4urq2i9kzdw86/small-logo.png?raw=1" width="35px">
 
 This repository contains the source code for the Zendesk AnyChannel: Youtube Integration as well as the Zendesk App Market Application. The service acts as a courier of data between Zendesk and the Youtube Data API V3. 


### PR DESCRIPTION
https://zendesk.atlassian.net/browse/EP-4297

Please review and approve at your convenience. This change replaces Travis with GitHub actions.
Once approved, please also merge.

If you have questions, reach us on #github-actions-migration Slack channel.

@zendesk/ocean 
